### PR TITLE
Fixed issue where path different from cfg caused cfg to be overwritte…

### DIFF
--- a/UnofficialCrusaderPatch/MainWindow.xaml.cs
+++ b/UnofficialCrusaderPatch/MainWindow.xaml.cs
@@ -129,7 +129,6 @@ namespace UCP
             if (Configuration.Path != cPath)
             {
                 Configuration.Path = cPath;
-                Configuration.Save("Path");
             }
 
             if (!viewLoaded)
@@ -137,6 +136,7 @@ namespace UCP
                 // load aic files
                 AICChange.LoadFiles();
                 Configuration.LoadChanges();
+                Configuration.Save("Path");
 
                 // fill setup options list
                 FillTreeView(Version.Changes);


### PR DESCRIPTION
This commit fixes an issue that occurs when the path from the ucp.cfg file is different from the path selected at the input prompt.

This is important to fix because the cfg files are normally shared for playing multiplayer and people may have Crusader installed to different locations

Reproducible as follows:
- Put path to any folder but Stronghold Crusader installation in the ucp.cfg file
- Launch UCP, click Browse and select correct path, then click continue
- All AIC settings specified in the ucp.cfg file are immediately removed and UCP-Bugfix.aic is auto-selected

The fix:
- After updating Configuration.Path load AIC changes from the ucp.cfg before writing to ucp.cfg