### PR TITLE
On AIC tab refresh reload AIC selection from ucp.cfg

### DIFF
--- a/UnofficialCrusaderPatch/AICs/AICChange.cs
+++ b/UnofficialCrusaderPatch/AICs/AICChange.cs
@@ -201,19 +201,28 @@ namespace UCP.Patching
 
             // load files
             if (Directory.Exists(aicFolder))
+            {
                 foreach (string filePath in Directory.EnumerateFiles(aicFolder, "*.aic"))
                 {
                     if (!TryLoadCollection(filePath, false, out AICCollection collection))
                         continue;
 
                     AICChange change = new AICChange(Path.GetFileName(filePath), collection);
-                    if (add2UI)
-                    {
-                        change.InitUI();
-                        View.Items.Add(change.UIElement);
-                    }
                     Version.Changes.Add(change);
                 }
+                Configuration.LoadChanges(true);
+                foreach (Change change in Version.Changes)
+                {
+                    if (change is AICChange aicChange && !aicChange.intern)
+                    {
+                        if (add2UI)
+                        {
+                            aicChange.InitUI();
+                            View.Items.Add(aicChange.UIElement);
+                        }
+                    }
+                }
+            }
         }
 
         #endregion

--- a/UnofficialCrusaderPatch/Configuration.cs
+++ b/UnofficialCrusaderPatch/Configuration.cs
@@ -81,7 +81,7 @@ namespace UCP
             loading = false;
         }
 
-        public static void LoadChanges()
+        public static void LoadChanges(bool aionly = false)
         {
             loading = true;
             if (File.Exists(ConfigFile))
@@ -96,7 +96,7 @@ namespace UCP
                         // change
                         string changeStr = line.Remove(index).Trim();
                         Change change = Version.Changes.Find(c => c.TitleIdent == changeStr);
-                        if (change == null) continue;
+                        if (change == null || (aionly == true && change.Type != ChangeType.AIC)) continue;
 
                         int startIndex = line.IndexOf('{', index + 1);
                         if (startIndex < 0) continue;


### PR DESCRIPTION
This commit updates UCP so that when the refresh button is clicked on the AIC tab the AIC selection settings are reloaded from the ucp.cfg file.

This allows users to hotswap aic files, useful when doing extensive modding and testing. This also would be extremely useful in the event that support for selecting multiple aic files returns as the user can insert a new aic, hit refresh, and only have to select the new aic file while the rest remain selected.

Previous behaviour:
When an internal aic file is selected and refresh is clicked the selection remains.
When a user-defined (local) aic file is selected and refresh is clicked the user has to go back and reselect the desired aic.

New behaviour
When an internal aic file is selected and refresh is clicked the selection remains.
When a user-defined (local) aic file is selected and refresh is clicked the user has to go back and reselect the desired aic.