### PR TITLE
Fixed localization issue causing inconsistency with decimal values

### DIFF
--- a/UnofficialCrusaderPatch/Patching/Headers/ValueHeader.cs
+++ b/UnofficialCrusaderPatch/Patching/Headers/ValueHeader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -77,7 +78,7 @@ namespace UCP.Patching
 
         public override string GetValueString()
         {
-            return string.Format("{0};{1}", this.IsEnabled, this.value);
+            return string.Format("{0};{1}", this.IsEnabled, this.value.ToString(CultureInfo.InvariantCulture));
         }
 
         public override void LoadValueString(string valueStr)
@@ -88,7 +89,7 @@ namespace UCP.Patching
             base.LoadValueString(valueStr.Remove(index));
 
             valueStr = valueStr.Substring(index + 1).Trim();
-            if (Double.TryParse(valueStr, out double result))
+            if (Double.TryParse(valueStr, NumberStyles.Any, CultureInfo.InvariantCulture, out double result))
                 this.value = result;
         }
     }


### PR DESCRIPTION
Fixed localization issue causing inconsistency when writing/reading double values (ValueHeader) to ucp.cfg

Reference issue: [comma or dot in the cfg file. #467](https://github.com/Sh0wdown/UnofficialCrusaderPatch/issues/467)

Fix: Write and read to ucp.cfg using CultureInfo.CultureInvariant (System.Globalization namespace)

Behaviour: 
ucp.cfg will always use a period for decimal (float) values
The **interface** will display the value based on OS's locale as that is what user will be more comfortable with. For example with 0.7
- English will show 0.7
- Deutsch will show 0,8

Compatibility:
Current ucp.cfg files using a comma separator will show incorrect number (ie. 0,7 will be 7). This is a one-time issue. Once the user corrects this once the change will be saved.

Testing:
Tested with English and Deutsch language in UI. Tested by changing the decimal separator to ',' instead of '.' on my own system.