### PR TITLE
Allow user to select multiple aic files using Ctrl+Click

### DIFF
--- a/UnofficialCrusaderPatch/AICs/AICChange.cs
+++ b/UnofficialCrusaderPatch/AICs/AICChange.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace UCP.Patching
 {
@@ -19,15 +20,19 @@ namespace UCP.Patching
         AICCollection collection;
         public AICCollection Collection => collection;
 
+
         string headerKey;
 
         protected override void TitleBox_Checked(object sender, RoutedEventArgs e)
         {
             base.TitleBox_Checked(sender, e);
-            foreach (var c in Version.Changes)
+            if (!(Keyboard.Modifiers == ModifierKeys.Control))
             {
-                if (c != this && c is AICChange)
-                    c.IsChecked = false;
+                foreach (var c in Version.Changes)
+                {
+                    if (c != this && c is AICChange)
+                        c.IsChecked = false;
+                }
             }
         }
 

--- a/UnofficialCrusaderPatch/MainWindow.xaml
+++ b/UnofficialCrusaderPatch/MainWindow.xaml
@@ -40,11 +40,12 @@
             Width="{Binding ActualWidth, RelativeSource = {RelativeSource AncestorType = {x:Type Grid}}}"
             Height="{Binding ActualHeight, RelativeSource ={RelativeSource AncestorType = {x:Type Grid}}}">
 
-            <TabControl x:Name="tabControl" HorizontalAlignment="Center" Height="238" Margin="0,56,0,0" VerticalAlignment="Top" Width="470" Background="#CCFFFFFF" Focusable="true"/>
+            <TabControl x:Name="tabControl" HorizontalAlignment="Center" Height="238" Margin="0,56,0,0" VerticalAlignment="Top" Width="470" Background="#CCFFFFFF" Focusable="true" SelectionChanged="tabControl_SelectionChanged"/>
             <ProgressBar x:Name="pbSetup" HorizontalAlignment="Center" Height="19" Margin="0,0,0,53" VerticalAlignment="Bottom" Width="468" Background="#99FFFFFF" Foreground="#FF832708"/>
             <Button x:Name="iButtonBack" Content="Zurück" HorizontalAlignment="Left" Height="30" Margin="8,0,0,13" VerticalAlignment="Bottom" Width="120" Click="iButtonBack_Click"/>
             <Button x:Name="iButtonInstall" Content="Installieren" HorizontalAlignment="Right" Height="30" Margin="0,0,8,13" VerticalAlignment="Bottom" Width="120" Click="iButtonInstall_Click"/>
             <Label x:Name="pbLabel" HorizontalAlignment="Center" Height="40" Margin="0,0,0,43" VerticalAlignment="Bottom" Width="468" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" FontWeight="Bold" FontSize="16"/>
+            <TextBlock x:Name="changeHint" HorizontalAlignment="Center" Height="19" Margin="0,0,0,53" VerticalAlignment="Bottom" Width="468" Background="#99FFFFFF" Foreground="#FF832708" TextAlignment="Center"/>
         </Grid>
     </Grid>
 </Window>

--- a/UnofficialCrusaderPatch/MainWindow.xaml.cs
+++ b/UnofficialCrusaderPatch/MainWindow.xaml.cs
@@ -142,7 +142,6 @@ namespace UCP
                 FillTreeView(Version.Changes);
                 viewLoaded = true;
             }
-
             pathGrid.Visibility = Visibility.Hidden;
             installGrid.Visibility = Visibility.Visible;
         }
@@ -170,12 +169,12 @@ namespace UCP
                 Debug.Error(Localization.Get("ui_wrongpath"));
                 return;
             }
-
             iButtonInstall.IsEnabled = false;
             pButtonSearch.IsEnabled = false;
             pTextBoxPath.IsReadOnly = true;
             Version.Changes.ForEach(c => c.SetUIEnabled(false));
             pbLabel.Content = "";
+            changeHint.Text = "";
 
             setupThread = new Thread(DoSetup);
             this.Closed += (s, args) => setupThread.Abort();
@@ -270,6 +269,17 @@ namespace UCP
             }
         }
 
+        void tabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            TabControl tab = (TabControl) sender;
+            if ((String) (((TabItem) tab.SelectedItem).Header) == "AIC"){
+                changeHint.Text = "Ctrl+Click to select multiple aic files";
+            } else
+            {
+                changeHint.Text = "";
+            }
+        }
+
         static void View_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
         {
             TreeView view = (TreeView)sender;
@@ -287,6 +297,5 @@ namespace UCP
         }
 
         #endregion
-        
     }
 }


### PR DESCRIPTION
This restores ability to select multiple aic files.

Motivation:
For users that would like to swap out AI personalities and keep the ones they'll swap regularly in different aic files (ie. I am testing a Rat personality and the rest are staying the same).

Using CTRL+Click to allow for multiple selection prevents the 'average user' from accidentally selecting multiple aics.


Old behaviour:
A single aic file can be selected by user

New behaviour:
By holding CTRL key when selecting aic file you can select multiple. (Likewise when holding CTRL key with multiple selected you can deselect a single aic, instead of all)