### PR TITLE
Rename assembly name to avoid conflict

### DIFF
--- a/UnofficialCrusaderPatchGUI/UnofficialCrusaderPatchGUI.csproj
+++ b/UnofficialCrusaderPatchGUI/UnofficialCrusaderPatchGUI.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{FFBFC874-6EAF-4B9C-8507-BBD5A9399CB5}</ProjectGuid>
     <OutputType>WinExe</OutputType>
     <RootNamespace>UCP</RootNamespace>
-    <AssemblyName>UnofficialCrusaderPatch</AssemblyName>
+    <AssemblyName>UnofficialCrusaderPatchGUI</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
Fixed output assembly name conflict that caused failure to load correct dependency