### PR TITLE
Update AIV installation behaviour

### DIFF
--- a/UnofficialCrusaderPatch/AIV/AIVChange.cs
+++ b/UnofficialCrusaderPatch/AIV/AIVChange.cs
@@ -326,16 +326,16 @@ namespace UCP.AIV
                     MessageBoxResult result = System.Windows.MessageBox.Show(Localization.Get("aiv_prompt"), "", MessageBoxButton.YesNoCancel);
                     if (result == MessageBoxResult.No)
                     {
-                        foreach (FileInfo file in backupDir.GetFiles())
+                        foreach (FileInfo file in destinationDir.GetFiles())
                         {
                             file.Delete();
                         }
 
-                        foreach (string aivFile in destinationDir.GetFiles().ToList().Select(x => x.Name))
+                        /*foreach (string aivFile in destinationDir.GetFiles().ToList().Select(x => x.Name))
                         {
                             FileInfo srcFile = new FileInfo(Path.Combine(destinationDir.FullName, aivFile));
                             srcFile.MoveTo(Path.Combine(backupDir.FullName, aivFile));
-                        }
+                        }*/
                     }
                     else if (result == MessageBoxResult.Yes) // Clear destination aiv folder of aiv files.
                     {

--- a/UnofficialCrusaderPatch/AIV/AIVChange.cs
+++ b/UnofficialCrusaderPatch/AIV/AIVChange.cs
@@ -3,9 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Security.Cryptography;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Forms;
 using System.Windows.Media;
 using UCP.Patching;
 
@@ -171,33 +174,248 @@ namespace UCP.AIV
         /// Copies AIV sets to aivDir (aiv subdirectory of SHC installation)
         /// </summary>
         /// <param name="aivDir"></param>
-        public void CopyAIVs(DirectoryInfo aivDir)
+        internal bool CopyAIVs(DirectoryInfo destinationDir, bool overwrite, bool graphical)
         {
-            if (this.resFolder.StartsWith("UCP.AIV"))
+            bool IsInternal = this.resFolder.StartsWith("UCP.AIV");
+            /*if (1 == 1) throw new Exception();*/
+            Assembly asm = Assembly.GetExecutingAssembly();
+            List<string> resourceFiles;
+            if (IsInternal)
             {
-                int len = resFolder.Length + 1;
-                Assembly asm = Assembly.GetExecutingAssembly();
-                foreach (string res in asm.GetManifestResourceNames())
-                {
-                    if (!res.StartsWith(resFolder, StringComparison.OrdinalIgnoreCase))
-                        continue;
+                resourceFiles = asm.GetManifestResourceNames()
+                    .Where(x => x.StartsWith(resFolder, StringComparison.OrdinalIgnoreCase)).Select(x => Path.GetFileName(x.Replace(resFolder + ".", ""))).ToList();
+            }
+            else
+            {
+                resourceFiles = Directory.GetFiles(Path.Combine("resources", "aiv", resFolder)).Where(x => x.EndsWith(".aiv")).Select(x => Path.GetFileName(ReplaceFirst(x, resFolder + Path.PathSeparator, ""))).ToList();
+            }
 
-                    string path = Path.Combine(aivDir.FullName, res.Substring(len));
-                    using (Stream stream = asm.GetManifestResourceStream(res))
-                    using (FileStream fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read))
+            // If same AIV exist in both check if contents identical
+            bool isIdentical = true;
+            if (destinationDir.GetFiles().ToList().Select(x => x.Name).Where(x => x.EndsWith(".aiv")).SequenceEqual(resourceFiles, StringComparer.CurrentCultureIgnoreCase))
+            {
+                foreach (string aivFile in resourceFiles)
+                {
+                    using (SHA256 SHA256Instance = SHA256.Create())
                     {
-                        stream.CopyTo(fs);
+                        using (Stream dstStream =
+                            new FileInfo(Path.Combine(destinationDir.FullName, aivFile)).OpenRead())
+                        {
+                            using (Stream srcStream = IsInternal ? asm.GetManifestResourceStream(resFolder + "." + aivFile) : new FileInfo(Path.Combine("resources", "aiv", resFolder, aivFile)).OpenRead())
+                            {
+                                if (!Convert.ToBase64String(SHA256Instance.ComputeHash(srcStream))
+                                    .Equals(Convert.ToBase64String(SHA256Instance.ComputeHash(dstStream))))
+                                {
+                                    isIdentical = false;
+                                    break;
+                                }
+                            }
+                        }
                     }
                 }
             }
             else
             {
-                foreach (var file in Directory.EnumerateFiles(Path.Combine("resources","aiv",this.resFolder), "*.aiv", SearchOption.TopDirectoryOnly))
+                isIdentical = false;
+            }
+
+            if (isIdentical)
+            {
+                return true;
+            }
+
+            // If overwrite, delete aiv contents of aiv directory and write new AIV files
+            if (overwrite)
+            {
+                foreach (FileInfo file in destinationDir.GetFiles())
                 {
-                    string path = Path.Combine(aivDir.FullName, Path.GetFileName(file));
-                    File.Copy(file, path);
+                    file.Delete();
+                }
+
+                foreach (string aivFile in resourceFiles)
+                {
+                    using (Stream dstStream =
+                        new FileInfo(Path.Combine(destinationDir.FullName, aivFile)).OpenWrite())
+                    {
+                        using (Stream srcStream = IsInternal
+                            ? asm.GetManifestResourceStream(resFolder + "." + aivFile)
+                            : new FileInfo(Path.Combine("resources", "aiv", resFolder, aivFile)).OpenRead())
+                        {
+                            srcStream.CopyTo(dstStream);
+                        }
+                    }
+                }
+                return true;
+            }
+
+            /**
+             * This logic runs when the contents of the backup and destination aiv folders are different.
+             * If an existing subfolder named 'original' does not exist in the destination aiv folder
+             *  - Create folder 'original'
+             *  - Copy all files from destination aiv folder to 'original' folder
+             *  - Copy new aiv files to destination aiv folder
+             */
+            DirectoryInfo backupDir = new DirectoryInfo(Path.Combine(destinationDir.FullName, "original"));
+            if (!Directory.Exists(Path.Combine(destinationDir.FullName, "original")) || backupDir.GetFiles().Length == 0)
+            {
+                if (Directory.EnumerateFiles(destinationDir.FullName, "*", SearchOption.TopDirectoryOnly).Select(x => x.EndsWith(".aiv")).ToList().Count > 0)
+                {
+                    backupDir.Create();
+                }
+                foreach (string aivFile in destinationDir.GetFiles().ToList().Select(x => x.Name))
+                {
+                    using (Stream dstStream =
+                        new FileInfo(Path.Combine(backupDir.FullName, aivFile)).OpenWrite())
+                    {
+                        using (Stream srcStream = new FileInfo(Path.Combine(destinationDir.FullName, aivFile)).OpenRead())
+                        {
+                            srcStream.CopyTo(dstStream);
+                        }
+                        File.Delete(Path.Combine(destinationDir.FullName, aivFile));
+                    }
                 }
             }
+            else
+            {
+                // Determine if the aiv files in destination folder are identical to backup folder
+                bool backupIdentical = true;
+                foreach (string aivFile in destinationDir.GetFiles().ToList().Where(x => x.Name.EndsWith(".aiv")).Select(x => x.Name))
+                {
+                    using (SHA256 SHA256Instance = SHA256.Create())
+                    {
+                        try
+                        {
+                            using (Stream dstStream =
+                                new FileInfo(Path.Combine(backupDir.FullName, aivFile)).OpenRead())
+                            {
+                                using (Stream srcStream = new FileInfo(Path.Combine(destinationDir.FullName, aivFile)).OpenRead())
+                                {
+                                    if (!Convert.ToBase64String(SHA256Instance.ComputeHash(srcStream))
+                                        .Equals(Convert.ToBase64String(SHA256Instance.ComputeHash(dstStream))))
+                                    {
+                                        backupIdentical = false;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        catch (IOException)
+                        {
+                            backupIdentical = false;
+                        }
+                    }
+                }
+
+                // If backup contains all aiv files from destination folder then delete aiv from destination folder
+                if (backupIdentical)
+                {
+                    foreach (FileInfo file in destinationDir.GetFiles())
+                    {
+                        if (file.Extension.Equals(".aiv"))
+                        {
+                            file.Delete();
+                        }
+                    }
+                }
+
+                /**
+                  * This logic runs when the contents of the backup and destination aiv folders are different.
+                  */
+                if (!backupIdentical && graphical) // Clear backup folder of aiv files
+                {
+                    MessageBoxResult result = System.Windows.MessageBox.Show(Localization.Get("aiv_prompt"), "", MessageBoxButton.YesNoCancel);
+                    if (result == MessageBoxResult.No)
+                    {
+                        foreach (FileInfo file in backupDir.GetFiles())
+                        {
+                            file.Delete();
+                        }
+
+                        foreach (string aivFile in destinationDir.GetFiles().ToList().Select(x => x.Name))
+                        {
+                            FileInfo srcFile = new FileInfo(Path.Combine(destinationDir.FullName, aivFile));
+                            srcFile.MoveTo(Path.Combine(backupDir.FullName, aivFile));
+                        }
+                    }
+                    else if (result == MessageBoxResult.Yes) // Clear destination aiv folder of aiv files.
+                    {
+                        using (var dialog = new FolderBrowserDialog())
+                        {
+                            dialog.Description = Localization.Get("backup_aiv_select");
+                            dialog.RootFolder = Environment.SpecialFolder.Desktop;
+                            DialogResult folderResult = DialogResult.Cancel;
+                            var thread = new Thread(obj => {
+                                folderResult = dialog.ShowDialog();
+                            });
+                            thread.SetApartmentState(ApartmentState.STA);
+                            thread.Start();
+                            thread.Join();
+
+                            if (folderResult == DialogResult.OK && !string.IsNullOrWhiteSpace(dialog.SelectedPath))
+                            {
+                                DirectoryInfo savePath = new DirectoryInfo(dialog.SelectedPath);
+                                string[] files = Directory.GetFiles(dialog.SelectedPath);
+
+                                foreach (FileInfo file in destinationDir.GetFiles())
+                                {
+                                    file.MoveTo(Path.Combine(savePath.FullName, Path.GetFileName(file.Name)));
+                                }
+                            } else
+                            {
+                                throw new Exception();
+                            }
+                        }
+                    }
+                    else
+                    {
+                        throw new Exception();
+                    }
+                }
+                else if (!backupIdentical)
+                {
+                    string input = "";
+                    while (!input.ToLower().Equals("delete") && (input.IndexOfAny(Path.GetInvalidPathChars()) != -1 || (input.Equals("") || Directory.Exists(Path.Combine(destinationDir.FullName, input)))))
+                    {
+                        Console.WriteLine(Localization.Get("aiv_cli_prompt"));
+                        input = Console.ReadLine().Replace("\n", "");
+                    };
+
+                    if (input.ToLower().Equals("delete"))
+                    {
+                        foreach (string file in Directory.EnumerateFiles(destinationDir.FullName, "*", SearchOption.TopDirectoryOnly))
+                        {
+                            File.Delete(file);
+                        }
+                    }
+                    else
+                    {
+                        DirectoryInfo extraBackupDir = Directory.CreateDirectory(Path.Combine(destinationDir.FullName, input));
+                        foreach (string file in Directory.EnumerateFiles(backupDir.FullName, "*", SearchOption.TopDirectoryOnly))
+                        {
+                            File.Move(file, Path.Combine(extraBackupDir.FullName, Path.GetFileName(file)));
+                        }
+                    }
+                    foreach (string file in Directory.EnumerateFiles(destinationDir.FullName, "*", SearchOption.TopDirectoryOnly))
+                    {
+                        File.Move(file, Path.Combine(backupDir.FullName, Path.GetFileName(file)));
+                    }
+                }
+            }
+
+            foreach (string aivFile in resourceFiles)
+            {
+                using (Stream dstStream =
+                    new FileInfo(Path.Combine(destinationDir.FullName, aivFile)).OpenWrite())
+                {
+                    using (Stream srcStream = IsInternal
+                        ? asm.GetManifestResourceStream(resFolder + "." + aivFile)
+                        : new FileInfo(Path.Combine("resources", "aiv", resFolder, aivFile)).OpenRead())
+                    {
+                        srcStream.CopyTo(dstStream);
+                    }
+                }
+            }
+            return true;
         }
 
         public static void Refresh()
@@ -227,46 +445,53 @@ namespace UCP.AIV
         /// Restores the most recently backed-up AIV set found in the aiv subfolder of SHC installation
         /// </summary>
         /// <param name="dir"></param>
-        public static void Restore(string dir)
+        internal static void Restore(string path)
         {
-            string aivPath = Path.Combine(dir, "aiv");
-            foreach (string file in Directory.EnumerateFiles(aivPath, "*.aiv", SearchOption.TopDirectoryOnly))
+            DirectoryInfo destinationDir = new DirectoryInfo(Path.Combine(path, "aiv"));
+            DirectoryInfo backupDir = new DirectoryInfo(Path.Combine(destinationDir.FullName, "original"));
+            if (!backupDir.Exists)
             {
-                File.Delete(file);
+                return;
             }
-            try
+            else
             {
-                DirectoryInfo bupDir = new DirectoryInfo(Path.Combine(aivPath)).GetDirectories().OrderByDescending(d => d.LastWriteTimeUtc).First();
-                if (bupDir.Exists)
+                foreach (FileInfo file in destinationDir.GetFiles())
                 {
-                    foreach (FileInfo fi in bupDir.EnumerateFiles("*.aiv"))
-                        fi.CopyTo(Path.Combine(aivPath, fi.Name), true);
-
-                    bupDir.Delete(true);
+                    if (file.Extension.Equals(".aiv"))
+                    {
+                        file.Delete();
+                    }
                 }
+
+                foreach (FileInfo file in backupDir.GetFiles())
+                {
+                    file.MoveTo(Path.Combine(destinationDir.FullName, Path.GetFileName(file.Name)));
+                }
+                backupDir.Delete();
             }
-            catch (InvalidOperationException) { }
         }
 
         /// <summary>
         /// Creates timestamped backup of existing AIV sets and copies selected AIV set to aivDir (aiv subdirectory of SHC installation)
         /// </summary>
         /// <param name="folderPath"></param>
-        public static void DoChange(string folderPath)
+        public static void DoChange(string folderPath, bool overwrite, bool graphical)
         {
-            DirectoryInfo aivDir = new DirectoryInfo(Path.Combine(folderPath, "aiv"));
-
-            if (AIVChange.ActiveChange != null)
+            if (activeChange == null)
             {
-                // create backup of current AIVs
-                DirectoryInfo bupDir = Directory.CreateDirectory(Path.Combine(aivDir.FullName, "bak-" + DateTime.Now.ToString("yyyy-MM-ddTHHmmss")));
-                foreach (string file in Directory.EnumerateFiles(aivDir.FullName, "*.aiv", SearchOption.TopDirectoryOnly))
-                {
-                    File.Move(file, Path.Combine(bupDir.FullName, Path.GetFileName(file)));
-                }
-                // copy modded AIVs
-                AIVChange.ActiveChange.CopyAIVs(aivDir);
+                return;
             }
+            activeChange.CopyAIVs(new DirectoryInfo(Path.Combine(folderPath, "aiv")), overwrite, graphical);
+        }
+
+        static string ReplaceFirst(string text, string search, string replace)
+        {
+            int pos = text.IndexOf(search);
+            if (pos < 0)
+            {
+                return text;
+            }
+            return text.Substring(0, pos) + replace + text.Substring(pos + search.Length);
         }
 
         private static String GetLocalizedDescription(string titleIdent)

--- a/UnofficialCrusaderPatch/Localization/Chinese.txt
+++ b/UnofficialCrusaderPatch/Localization/Chinese.txt
@@ -31,6 +31,11 @@ aiv_cli_prompt
 "Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
 }
 
+install_abort_io
+{
+"Installation aborted. Files with the same name already exist in this folder. Please try again and select a different folder."
+}
+
 install_abort
 {
 "Installation aborted"

--- a/UnofficialCrusaderPatch/Localization/Chinese.txt
+++ b/UnofficialCrusaderPatch/Localization/Chinese.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Localization/Chinese.txt
+++ b/UnofficialCrusaderPatch/Localization/Chinese.txt
@@ -21,6 +21,26 @@ delete_housing_descr
 "After the AI has reached this additional amount of available housing after it stopped building houses, it will delete houses"
 }
 
+aiv_prompt
+{
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+}
+
+aiv_cli_prompt
+{
+"Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
+}
+
+install_abort
+{
+"Installation aborted"
+}
+
+backup_aiv_select
+{
+"Select Backup AIV folder"
+}
+
 o_change_siege_engine_spawn_position_catapult
 {
 "Center siege engine spawn position"

--- a/UnofficialCrusaderPatch/Localization/Chinese.txt
+++ b/UnofficialCrusaderPatch/Localization/Chinese.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
+"Custom modified AIVs detected. Before installing, click 'Yes' to save the currently installed AIVs without overwriting the original backup. Click 'No' to overwrite installed AIVs without backing them up, and 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Localization/English.txt
+++ b/UnofficialCrusaderPatch/Localization/English.txt
@@ -31,6 +31,11 @@ aiv_cli_prompt
 "Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
 }
 
+install_abort_io
+{
+"Installation aborted. Files with the same name already exist in this folder. Please try again and select a different folder."
+}
+
 install_abort
 {
 "Installation aborted"

--- a/UnofficialCrusaderPatch/Localization/English.txt
+++ b/UnofficialCrusaderPatch/Localization/English.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Localization/English.txt
+++ b/UnofficialCrusaderPatch/Localization/English.txt
@@ -21,6 +21,26 @@ delete_housing_descr
 "After the AI has reached this additional amount of available housing after it stopped building houses, it will delete houses"
 }
 
+aiv_prompt
+{
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+}
+
+aiv_cli_prompt
+{
+"Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
+}
+
+install_abort
+{
+"Installation aborted"
+}
+
+backup_aiv_select
+{
+"Select Backup AIV folder"
+}
+
 o_change_siege_engine_spawn_position_catapult
 {
 "Center siege engine spawn position"

--- a/UnofficialCrusaderPatch/Localization/English.txt
+++ b/UnofficialCrusaderPatch/Localization/English.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
+"Custom modified AIVs detected. Before installing, click 'Yes' to save the currently installed AIVs without overwriting the original backup. Click 'No' to overwrite installed AIVs without backing them up, and 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Localization/German.txt
+++ b/UnofficialCrusaderPatch/Localization/German.txt
@@ -21,6 +21,26 @@ delete_housing_descr
 "After the AI has reached this additional amount of available housing after it stopped building houses, it will delete houses"
 }
 
+aiv_prompt
+{
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+}
+
+aiv_cli_prompt
+{
+"Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
+}
+
+install_abort
+{
+"Installation aborted"
+}
+
+backup_aiv_select
+{
+"Select Backup AIV folder"
+}
+
 o_change_siege_engine_spawn_position_catapult
 {
 "Zentriert Belagerungsgeräte nach der Konstruktion"

--- a/UnofficialCrusaderPatch/Localization/German.txt
+++ b/UnofficialCrusaderPatch/Localization/German.txt
@@ -31,6 +31,11 @@ aiv_cli_prompt
 "Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
 }
 
+install_abort_io
+{
+"Installation aborted. Files with the same name already exist in this folder. Please try again and select a different folder."
+}
+
 install_abort
 {
 "Installation aborted"

--- a/UnofficialCrusaderPatch/Localization/German.txt
+++ b/UnofficialCrusaderPatch/Localization/German.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Localization/German.txt
+++ b/UnofficialCrusaderPatch/Localization/German.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
+"Custom modified AIVs detected. Before installing, click 'Yes' to save the currently installed AIVs without overwriting the original backup. Click 'No' to overwrite installed AIVs without backing them up, and 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Localization/Hungarian.txt
+++ b/UnofficialCrusaderPatch/Localization/Hungarian.txt
@@ -31,6 +31,11 @@ aiv_cli_prompt
 "Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
 }
 
+install_abort_io
+{
+"Installation aborted. Files with the same name already exist in this folder. Please try again and select a different folder."
+}
+
 install_abort
 {
 "Installation aborted"

--- a/UnofficialCrusaderPatch/Localization/Hungarian.txt
+++ b/UnofficialCrusaderPatch/Localization/Hungarian.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Localization/Hungarian.txt
+++ b/UnofficialCrusaderPatch/Localization/Hungarian.txt
@@ -21,6 +21,26 @@ delete_housing_descr
 "After the AI has reached this additional amount of available housing after it stopped building houses, it will delete houses"
 }
 
+aiv_prompt
+{
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+}
+
+aiv_cli_prompt
+{
+"Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
+}
+
+install_abort
+{
+"Installation aborted"
+}
+
+backup_aiv_select
+{
+"Select Backup AIV folder"
+}
+
 o_change_siege_engine_spawn_position_catapult
 {
 "Center siege engine spawn position"

--- a/UnofficialCrusaderPatch/Localization/Hungarian.txt
+++ b/UnofficialCrusaderPatch/Localization/Hungarian.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
+"Custom modified AIVs detected. Before installing, click 'Yes' to save the currently installed AIVs without overwriting the original backup. Click 'No' to overwrite installed AIVs without backing them up, and 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Localization/Polish.txt
+++ b/UnofficialCrusaderPatch/Localization/Polish.txt
@@ -31,6 +31,11 @@ aiv_cli_prompt
 "Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
 }
 
+install_abort_io
+{
+"Installation aborted. Files with the same name already exist in this folder. Please try again and select a different folder."
+}
+
 install_abort
 {
 "Installation aborted"

--- a/UnofficialCrusaderPatch/Localization/Polish.txt
+++ b/UnofficialCrusaderPatch/Localization/Polish.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Localization/Polish.txt
+++ b/UnofficialCrusaderPatch/Localization/Polish.txt
@@ -21,6 +21,26 @@ delete_housing_descr
 "After the AI has reached this additional amount of available housing after it stopped building houses, it will delete houses"
 }
 
+aiv_prompt
+{
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+}
+
+aiv_cli_prompt
+{
+"Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
+}
+
+install_abort
+{
+"Installation aborted"
+}
+
+backup_aiv_select
+{
+"Select Backup AIV folder"
+}
+
 o_change_siege_engine_spawn_position_catapult
 {
 "Center siege engine spawn position"

--- a/UnofficialCrusaderPatch/Localization/Polish.txt
+++ b/UnofficialCrusaderPatch/Localization/Polish.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
+"Custom modified AIVs detected. Before installing, click 'Yes' to save the currently installed AIVs without overwriting the original backup. Click 'No' to overwrite installed AIVs without backing them up, and 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Localization/Russian.txt
+++ b/UnofficialCrusaderPatch/Localization/Russian.txt
@@ -31,6 +31,11 @@ aiv_cli_prompt
 "Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
 }
 
+install_abort_io
+{
+"Installation aborted. Files with the same name already exist in this folder. Please try again and select a different folder."
+}
+
 install_abort
 {
 "Installation aborted"

--- a/UnofficialCrusaderPatch/Localization/Russian.txt
+++ b/UnofficialCrusaderPatch/Localization/Russian.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Localization/Russian.txt
+++ b/UnofficialCrusaderPatch/Localization/Russian.txt
@@ -21,6 +21,26 @@ delete_housing_descr
 "After the AI has reached this additional amount of available housing after it stopped building houses, it will delete houses"
 }
 
+aiv_prompt
+{
+"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, 'No' to overwrite and delete original backup, 'Cancel' to cancel."
+}
+
+aiv_cli_prompt
+{
+"Custom modified AIVs detected. Enter 'delete' to erase or enter folder name to copy files to."
+}
+
+install_abort
+{
+"Installation aborted"
+}
+
+backup_aiv_select
+{
+"Select Backup AIV folder"
+}
+
 o_change_siege_engine_spawn_position_catapult
 {
 "Center siege engine spawn position"

--- a/UnofficialCrusaderPatch/Localization/Russian.txt
+++ b/UnofficialCrusaderPatch/Localization/Russian.txt
@@ -23,7 +23,7 @@ delete_housing_descr
 
 aiv_prompt
 {
-"Custom modified AIVs detected. Click 'Yes' to backup then clear modified files, installing new AIVs, 'No' to overwrite and delete original backup, and install new AIVs, 'Cancel' to cancel."
+"Custom modified AIVs detected. Before installing, click 'Yes' to save the currently installed AIVs without overwriting the original backup. Click 'No' to overwrite installed AIVs without backing them up, and 'Cancel' to cancel."
 }
 
 aiv_cli_prompt

--- a/UnofficialCrusaderPatch/Patching/Patcher.cs
+++ b/UnofficialCrusaderPatch/Patching/Patcher.cs
@@ -40,8 +40,12 @@ namespace UCP.Patching
 
             perc.NextLimit = 0.1;
 
-            try {
+            try
+            {
                 AIVChange.DoChange(folderPath, overwrite, graphical);
+            } catch (IOException) {
+                Debug.Show(Localization.Get("install_abort_io"));
+                return;
             } catch (Exception)
             {
                 Debug.Show(Localization.Get("install_abort"));

--- a/UnofficialCrusaderPatch/Patching/Patcher.cs
+++ b/UnofficialCrusaderPatch/Patching/Patcher.cs
@@ -33,13 +33,20 @@ namespace UCP.Patching
             path = Path.Combine(folderPath, XtremeExe);
             return File.Exists(path);
         }
-        public static void Install(string folderPath, Percentage.SetHandler SetPercent)
+        public static void Install(string folderPath, Percentage.SetHandler SetPercent, bool overwrite, bool graphical)
         {
             Percentage perc = new Percentage(SetPercent);
             perc.SetTotal(0);
 
             perc.NextLimit = 0.1;
-            AIVChange.DoChange(folderPath);
+
+            try {
+                AIVChange.DoChange(folderPath, overwrite, graphical);
+            } catch (Exception)
+            {
+                Debug.Show(Localization.Get("install_abort"));
+                return;
+            }
             perc.Set(1.0);
 
             DoChanges(folderPath, perc);

--- a/UnofficialCrusaderPatch/Version.cs
+++ b/UnofficialCrusaderPatch/Version.cs
@@ -13,7 +13,7 @@ namespace UCP
 {
     public class Version
     {
-        public static string PatcherVersion = "-KI-Turnier";
+        public static string PatcherVersion = "2.15";
 
         // change version 0x424EF1 + 1
         public static readonly ChangeHeader MenuChange = new ChangeHeader()

--- a/UnofficialCrusaderPatchConsole/Program.cs
+++ b/UnofficialCrusaderPatchConsole/Program.cs
@@ -79,7 +79,7 @@ namespace UCP
         static void SilentInstall()
         {
             Version.Changes.Contains(null);
-            Patcher.Install(Configuration.Path, null);
+            Patcher.Install(Configuration.Path, null, false, false);
             Console.WriteLine("UCP successfully installed");
             Console.WriteLine("Path to Stronghold Crusader is:" + Configuration.Path);
         }

--- a/UnofficialCrusaderPatchGUI/MainWindow.xaml.cs
+++ b/UnofficialCrusaderPatchGUI/MainWindow.xaml.cs
@@ -238,7 +238,7 @@ namespace UCP
         {
             try
             {
-                Patcher.Install((string)arg, SetPercent);
+                Patcher.Install((string)arg, SetPercent, false, true);
 
                 Dispatcher.Invoke(DispatcherPriority.Render, new Action(() =>
                 {


### PR DESCRIPTION
Creating PR to address the #643, #715 for the UnofficialCrusaderPatchGUI project. CLI will be looked at separately.

- If no AIV backup is present and install clicked, AIVs will be backed up to 'original' folder and new AIVs installed.
- If no AIV backup is present and uninstall clicked, no AIVs will be modified.
- If backup files are identical and install clicked, existing AIVs will be deleted, new AIVs installed.
- If backup files are different then a dialog will show prompting user to a) Backup then clear modified files b) Overwrite and delete original backup c) cancel
- If user cancels at any point then installation will be cancelled
- If user chooses to overwrite the modified files will overwrite the existing backup and new AIVs will be installed
- If user chooses to backup then clear modified files then a dialog will open up prompting user to select folder to save the modified files to. If user cancels this, then installation will abort.