### PR TITLE
Fix uninstallation does not remove the UCP backup files

### DIFF
--- a/UnofficialCrusaderPatch/Patching/Patcher.cs
+++ b/UnofficialCrusaderPatch/Patching/Patcher.cs
@@ -193,6 +193,7 @@ namespace UCP.Patching
                     File.Delete(oriPath);
 
                 File.Move(backupPath, oriPath);
+                File.Delete(backupPath);
             }
         }
 

--- a/UnofficialCrusaderPatchGUI/MainWindow.xaml
+++ b/UnofficialCrusaderPatchGUI/MainWindow.xaml
@@ -31,7 +31,7 @@
                     DockPanel.Dock="Left" 
                     Width="25" Height="20"/>
 
-            <TextBlock VerticalAlignment="Center">Unofficial Crusader Patch KI-Turnier</TextBlock>
+            <TextBlock VerticalAlignment="Center">Unofficial Crusader Patch 2.15</TextBlock>
         </DockPanel>
         <Image Source="Graphics/frame.jpg" Margin="0,22.5,0,0" Stretch="UniformToFill" HorizontalAlignment="Center" VerticalAlignment="Top" Height="50" RenderTransformOrigin="0.5,0.5">
             <Image.RenderTransform>


### PR DESCRIPTION
Uninstallation now removes the .ucp_backup files. This is important so that if user uninstalls and then changes version or language of their install the new executable is used rather than the stale backup.