### PR TITLE
Fix bug where missing entry in start troop config caused mismatch of remaining start troops

### DIFF
--- a/UnofficialCrusaderPatch/Startup/StartTroopChange.cs
+++ b/UnofficialCrusaderPatch/Startup/StartTroopChange.cs
@@ -516,6 +516,24 @@ namespace UCP.Startup
                         startTroopChanges.Add(new BinSkip(0xF0));
                     }
                 }
+                else
+                {
+                    startTroopChanges.Add(new BinSkip(80));
+                    startTroopChanges.Add(new BinSkip(80));
+                    startTroopChanges.Add(new BinSkip(80));
+
+                    if (playerIndex < 17)
+                    {
+                        lordStrengthChanges.Add(new BinSkip(0x4));
+                        lordStrengthChanges.Add(new BinSkip(0x4));
+                        lordTypeChanges.Add(new BinSkip(0x1));
+                    }
+
+                    if (playerIndex == 16)
+                    {
+                        startTroopChanges.Add(new BinSkip(0xF0));
+                    }
+                }
             }
 
             BinaryEdit troopEdit = new BinaryEdit(troopBlockFile);


### PR DESCRIPTION
There was apparently a bug where missing entry in start troop config caused mismatch of remaining start troops. This pull request addresses that.

Quick test: installed the below modified vanilla start troop config to remove snake and saw pig get modified appropriately.
https://pastebin.com/fauqv6Q8