### PR TITLE
[doc] Update CI

### DIFF
--- a/.github/workflows/dotnet-core-desktop.yml
+++ b/.github/workflows/dotnet-core-desktop.yml
@@ -6,14 +6,17 @@ name: UCP Build
 on:
   workflow_dispatch:
   push:
-    branches: [ master, GUI-Update ]
+    branches:
+      - !gh-pages
   pull_request:
-    branches: [ master, GUI-Update ]
+    branches:
+      - !gh-pages
     types: [assigned, opened, edited, ready_for_review, reopened, synchronize]
 
 jobs:
 
   build:
+    if: "!startsWith(github.event.head_commit.message, '[doc]')"
 
     strategy:
       matrix:


### PR DESCRIPTION
Allow pushes and pull requests to skip CI if prefixed with [doc] (to indicate documentation-only commit)