### PR TITLE
Revise AI housing change

### DIFF
--- a/UnofficialCrusaderPatch/Localization/Chinese.txt
+++ b/UnofficialCrusaderPatch/Localization/Chinese.txt
@@ -62,9 +62,19 @@ build_housing_descr
 "Number of extra available housing before AI stops building houses"
 }
 
+campfire_housing_descr
+{
+"Number of peasants at the campfire before the AI stops buildings houses"
+}
+
+delete_housing
+{
+"Disable the AI's ability to delete houses"
+}
+
 delete_housing_descr
 {
-"After the AI has reached this additional amount of available housing after it stopped building houses, it will delete houses"
+"When this option is selected the AI will never delete houses"
 }
 
 aiv_prompt

--- a/UnofficialCrusaderPatch/Localization/English.txt
+++ b/UnofficialCrusaderPatch/Localization/English.txt
@@ -62,9 +62,19 @@ build_housing_descr
 "Number of extra available housing before AI stops building houses"
 }
 
+campfire_housing_descr
+{
+"Number of campfire peasants at which AI stops building houses"
+}
+
+delete_housing
+{
+"Disable the AI's ability to delete houses"
+}
+
 delete_housing_descr
 {
-"After the AI has reached this additional amount of available housing after it stopped building houses, it will delete houses"
+"When this option is selected the AI will never delete houses"
 }
 
 aiv_prompt

--- a/UnofficialCrusaderPatch/Localization/English.txt
+++ b/UnofficialCrusaderPatch/Localization/English.txt
@@ -64,7 +64,7 @@ build_housing_descr
 
 campfire_housing_descr
 {
-"Number of campfire peasants at which AI stops building houses"
+"Number of peasants at the campfire before the AI stops buildings houses"
 }
 
 delete_housing

--- a/UnofficialCrusaderPatch/Localization/German.txt
+++ b/UnofficialCrusaderPatch/Localization/German.txt
@@ -48,22 +48,32 @@ ai_defense_descr
 
 ai_housing
 {
-"Passe an, wie die KI entscheidet, Häuser zu bauen und abzureißen"
+"Customize the AIs decision to build and delete houses"
 }
 
 ai_buildhousing_descr
 {
-"Passe an, wie die KI entscheidet, Häuser zu bauen und abzureißen"
+"Customize the AIs decision to build and delete houses"
 }
 
 build_housing_descr
 {
-"Anzahl zusätzlicher freier Behausungen bevor die KI aufhört, Hütten zu bauen"
+"Number of extra available housing before AI stops building houses"
+}
+
+campfire_housing_descr
+{
+"Number of peasants at the campfire before the AI stops buildings houses"
+}
+
+delete_housing
+{
+"Disable the AI's ability to delete houses"
 }
 
 delete_housing_descr
 {
-"Nachdem die KI diese zusätzliche Menge freier Behausungen erreicht hat, nachdem sie aufgehört hat, Hütten zu bauen, reißt sie Hütten ab"
+"When this option is selected the AI will never delete houses"
 }
 
 aiv_prompt

--- a/UnofficialCrusaderPatch/Localization/Hungarian.txt
+++ b/UnofficialCrusaderPatch/Localization/Hungarian.txt
@@ -48,24 +48,33 @@ ai_defense_descr
 
 ai_housing
 {
-"Az MI döntéseinek testreszabása a házak építése és lerombolásakor"
+"Customize the AIs decision to build and delete houses"
 }
 
 ai_buildhousing_descr
 {
-"Az MI döntéseinek testreszabása a házak építése és lerombolásakor"
+"Customize the AIs decision to build and delete houses"
 }
 
 build_housing_descr
 {
-"Extra építhető házak száma, mielőtt az MI nem épít több házat"
+"Number of extra available housing before AI stops building houses"
+}
+
+campfire_housing_descr
+{
+"Number of peasants at the campfire before the AI stops buildings houses"
+}
+
+delete_housing
+{
+"Disable the AI's ability to delete houses"
 }
 
 delete_housing_descr
 {
-"Amikor az MI eléri az extra építhető házak számát, miután az MI nem épít több házat, töröni fogja a házakat."
+"When this option is selected the AI will never delete houses"
 }
-
 aiv_prompt
 {
 "Módosított AIV fájlok észlelve. Telepítés előtt kattints az 'Igen' gombra, hogy elmentsd a jelenleg telepített AIV fájlokat, az eredeti backup felülírása nélkül. Kattints a 'Nem' gombra, hogy felülírd a telepített AIV fájlokat, nem készül róluk biztonsági mentés. Vagy kattints a 'Mégsem' gombra a telepítés megszakításához."

--- a/UnofficialCrusaderPatch/Localization/Polish.txt
+++ b/UnofficialCrusaderPatch/Localization/Polish.txt
@@ -62,11 +62,20 @@ build_housing_descr
 "Number of extra available housing before AI stops building houses"
 }
 
-delete_housing_descr
+campfire_housing_descr
 {
-"After the AI has reached this additional amount of available housing after it stopped building houses, it will delete houses"
+"Number of peasants at the campfire before the AI stops buildings houses"
 }
 
+delete_housing
+{
+"Disable the AI's ability to delete houses"
+}
+
+delete_housing_descr
+{
+"When this option is selected the AI will never delete houses"
+}
 aiv_prompt
 {
 "Custom modified AIVs detected. Before installing, click 'Yes' to save the currently installed AIVs without overwriting the original backup. Click 'No' to overwrite installed AIVs without backing them up, and 'Cancel' to cancel."

--- a/UnofficialCrusaderPatch/Localization/Russian.txt
+++ b/UnofficialCrusaderPatch/Localization/Russian.txt
@@ -48,22 +48,32 @@ ai_defense_descr
 
 ai_housing
 {
-"Настройка решения ИИ о строительстве и удалении домов"
+"Customize the AIs decision to build and delete houses"
 }
 
 ai_buildhousing_descr
 {
-"Настройка решения ИИ о строительстве и удалении домов"
+"Customize the AIs decision to build and delete houses"
 }
 
 build_housing_descr
 {
-"Количество дополнительного доступного жилья до того, как ИИ прекратит строительство домов"
+"Number of extra available housing before AI stops building houses"
+}
+
+campfire_housing_descr
+{
+"Number of peasants at the campfire before the AI stops buildings houses"
+}
+
+delete_housing
+{
+"Disable the AI's ability to delete houses"
 }
 
 delete_housing_descr
 {
-"После того, как ИИ достигнет этого дополнительного количества доступного жилья. ИИ прекратит строительство домов, ИИ будет удалять дома"
+"When this option is selected the AI will never delete houses"
 }
 
 aiv_prompt

--- a/UnofficialCrusaderPatch/Version.cs
+++ b/UnofficialCrusaderPatch/Version.cs
@@ -582,7 +582,7 @@ namespace UCP
 
             new Change("ai_housing", ChangeType.AILords, false, false)
             {
-                new SliderHeader("build_housing", false, 1, 200, 10, 12, 30)
+                new SliderHeader("build_housing", false, 1, 200, 1, 12, 30)
                 {
                     new BinaryEdit("ai_buildhousing")
                     {

--- a/UnofficialCrusaderPatch/Version.cs
+++ b/UnofficialCrusaderPatch/Version.cs
@@ -25,129 +25,6 @@ namespace UCP
             BinRedirect.CreateEdit("menuversion", false, Encoding.ASCII.GetBytes("V1.%d-E UCP" + PatcherVersion + '\0'))
         };
 
-        private static ParamHeader GetAIHousingParamHeader(Dictionary<string, Dictionary<string, object>> parameters)
-        {
-            BinCollection campPeasantCollection = null;
-
-            int paramSize = 1;
-            if (!parameters["build_housing"]["value"].Equals(false))
-            {
-                paramSize = (double)parameters["build_housing"]["value"] > 0x7F ? 3 : 1;
-            }
-                
-            if (!(parameters["build_housing"]["value"].Equals(false) || (double)parameters["build_housing"]["value"] == 0))
-            {
-                campPeasantCollection = new BinCollection()
-                {
-                    0x2B, 0x88, new BinRefTo("population_address", false),
-                };
-
-                BinCollection sizeCollection;
-                if (paramSize == 1)
-                {
-                    byte[] value = BitConverter.GetBytes(Convert.ToInt32((double)parameters["build_housing"]["value"]));
-                    sizeCollection = new BinCollection()
-                    {
-                        0x83, 0xF9, value[0]
-                    };
-                }
-                else
-                {
-                    sizeCollection = new BinCollection()
-                    {
-                        0x81, 0xF9, BitConverter.GetBytes(Convert.ToInt32((double)parameters["build_housing"]["value"]))
-                    };
-                }
-                foreach (var elem in sizeCollection) campPeasantCollection.Add(elem);
-
-                BinCollection jumpCollection = new BinCollection()
-                {
-                    0x7F, 0x05, /* if greater continue */
-                    0x33, 0xC0, /* xor eax, eax */
-                    0xC2, 0x08, 0x00 /* ret 0008 */
-                };
-
-                foreach (var elem in jumpCollection) campPeasantCollection.Add(elem);
-            }
-
-            double delete_value = Convert.ToInt32((double)parameters["delete_housing"]["value"]);
-            if (!(parameters["build_housing"]["value"].Equals(false)))
-            {
-                delete_value += (double)parameters["build_housing"]["value"];
-            } else
-            {
-                delete_value += 12;
-            }
-
-            paramSize = 1;
-            if (!parameters["delete_housing"]["value"].Equals(false))
-            {
-                paramSize = delete_value > 0x7F ? 3 : 1;
-            }
-            BinaryEdit delete_edit = null;
-            if (!(parameters["delete_housing"]["value"].Equals(false) || (double)parameters["delete_housing"]["value"] == 20))
-            {
-                byte[] value = BitConverter.GetBytes(Convert.ToInt32(delete_value));
-                delete_edit = new BinaryEdit("ai_deletehousing")
-                {
-                    new BinAddress("housing_address_new", 16),
-                    new BinSkip(0xF),
-                    new BinSkip(0x7),
-                    0xF7, 0xD9,
-                    new BinBytes(0x03, 0x88), new BinRefTo("housing_address_new", false),
-                    new BinHook(6)
-                    {
-                        paramSize == 1 ? new BinBytes(0x83, 0xF9, value[0]) : new BinBytes(0x81, 0xF9, value[0], value[1], value[2], value[3]),
-                        0x7F, 0x06,
-                        0x33, 0xC0,
-                        0x5F,
-                        0xC2, 0x04, 0x00
-                    }
-                    /*0x83, 0xF9, value[0],
-                    new BinBytes(0x7E, 0xDF),
-                    new BinNops(1)*/
-                };
-            }
-
-
-            BinBytes init = new BinBytes();
-
-            BinBytes finalizer = new BinBytes(
-                0xB8, 0x01, 0x00, 0x00, 0x00,   /* mov eax, 00000001 */
-                0xC2, 0x08, 0x00
-                );
-
-            BinHook hook = new BinHook(5)
-            {
-                init
-            };
-
-            if (campPeasantCollection != null)
-            {
-                foreach (var elem in campPeasantCollection) hook.Add(elem);
-            }
-
-            hook.Add(finalizer);
-
-            BinaryEdit edit = new BinaryEdit("ai_buildhousing")
-            {
-                hook,
-                new BinAddress("campfire_peasant_address", 0x22, false), //0x22
-                new BinAddress("population_address", 2, false), //5
-                new BinAddress("housing_address", 11, false), //11
-            };
-
-
-            ParamHeader aiHousing = new ParamHeader("ai_buildhousing")
-            {
-                edit == null ? new BinaryEdit("ai_buildhousing") : edit,
-                delete_edit == null ? new BinaryEdit("ai_deletehousing") : delete_edit
-            };
-            aiHousing.IsEnabled = (!parameters["build_housing"]["value"].Equals(false) && (double)parameters["build_housing"]["value"] != 12)
-                || (!parameters["delete_housing"]["value"].Equals(false) && (double)parameters["delete_housing"]["value"] != 20);
-            return aiHousing;
-        }
-
         static List<Change> changes = new List<Change>()
         {
             #region BUG FIXES
@@ -703,14 +580,57 @@ namespace UCP
 
             #region AI LORDS
 
-            new Change("ai_housing", ChangeType.AILords, false, false, 
-                (parameters) => {
-                    return GetAIHousingParamHeader(parameters);
-                })
+            new Change("ai_housing", ChangeType.AILords, false, false)
             {
-                new SliderHeader("build_housing", false, 0, 500, 1, 12, 30){},
+                new SliderHeader("build_housing", false, 1, 200, 10, 12, 30)
+                {
+                    new BinaryEdit("ai_buildhousing")
+                    {
+                        new BinAddress("population", 7),
+                        new BinHook(5)
+                        {
+                            0x81, 0xE9, new BinInt32Value(),
+                        },
+                        new BinSkip(6),
+                        0x7F, 0xDE
+                    },
 
-                new SliderHeader("delete_housing", false, 0, 500, 1, 20, 0x7F){},
+                    new BinaryEdit("ai_deletehousing")
+                    {
+                        new BinAddress("housing", 0x10),
+                        new BinSkip(22),
+                        new BinHook(5)
+                        {
+                            0x8B, 0x88, new BinRefTo("population", false),
+                            0x81, 0xE9, new BinInt32Value(),
+                            0x81, 0xE9, 0x18, 0x00, 0x00, 0x00,
+                            0x3B, 0x88, new BinRefTo("housing", false),
+                        },
+                        0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90
+                    }
+                },
+
+                new SliderHeader("campfire_housing", false, 0, 25, 1, 5, 20)
+                {
+                    new BinaryEdit("ai_buildhousing")
+                    {
+                        new BinSkip(0xB),
+                        0x7F, 0x08,
+                        new BinSkip(0x8),
+                        0xB9, new BinInt32Value(),
+                        new BinSkip(8),
+                        0x7C, 0xC7,
+                        0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90
+                    }
+                },
+
+                new DefaultHeader("delete_housing")
+                {
+                    new BinaryEdit("ai_deletehousing")
+                    {
+                        new BinBytes(0x90, 0x90)
+                    }
+                },
             },
 
 


### PR DESCRIPTION
Slider 1: Number of extra available housing before AI stops building houses
Slider 2: Number of campfire peasants at which AI stops building houses

(if Slider 1 and 2 are checked AI will stop building houses for either/both conditions)

Checkbox: Disable the AIs ability to delete houses.