### PR TITLE
Revert "[doc] Update CI"

### DIFF
--- a/.github/workflows/dotnet-core-desktop.yml
+++ b/.github/workflows/dotnet-core-desktop.yml
@@ -6,17 +6,14 @@ name: UCP Build
 on:
   workflow_dispatch:
   push:
-    branches:
-      - !gh-pages
+    branches: [ master, GUI-Update ]
   pull_request:
-    branches:
-      - !gh-pages
+    branches: [ master, GUI-Update ]
     types: [assigned, opened, edited, ready_for_review, reopened, synchronize]
 
 jobs:
 
   build:
-    if: "!startsWith(github.event.head_commit.message, '[doc]')"
 
     strategy:
       matrix:


### PR DESCRIPTION
Reverts Sh0wdown/UnofficialCrusaderPatch#742

Seems to exclude more than just docs, lets revert for now and do a new PR when we get an update on it.